### PR TITLE
CET-874 Add OkHTTP Caching to gitlab P1/2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.gitlab4j</groupId>
 	<artifactId>gitlab4j-api-cortex</artifactId>
 	<packaging>jar</packaging>
-	<version>4.20.4-SNAPSHOT</version>
+	<version>4.20.3</version>
 	<name>GitLab4J-API - GitLab API Java Client</name>
 	<description>GitLab4J-API (gitlab4j-api) provides a full featured Java client library for working with GitLab repositories and servers via the GitLab REST API.</description>
 	<url>https://github.com/gitlab4j/gitlab4j-api</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.gitlab4j</groupId>
 	<artifactId>gitlab4j-api-cortex</artifactId>
 	<packaging>jar</packaging>
-	<version>4.20.2</version>
+	<version>4.20.4-SNAPSHOT</version>
 	<name>GitLab4J-API - GitLab API Java Client</name>
 	<description>GitLab4J-API (gitlab4j-api) provides a full featured Java client library for working with GitLab repositories and servers via the GitLab REST API.</description>
 	<url>https://github.com/gitlab4j/gitlab4j-api</url>

--- a/src/main/java/org/gitlab4j/api/GitLabApi.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApi.java
@@ -642,6 +642,12 @@ public class GitLabApi implements AutoCloseable {
         apiClient.enableRequestResponseLogging(logger, level, maxEntitySize, maskedHeaderNames);
     }
 
+    /**
+     * Allow the user of the library to specify the javax Client implementation
+     * specified logger.
+     *
+     * @param apiClient the client instance that the GitlabApiClient can use
+     */
     public void setApiClient(Client apiClient) {
         this.apiClient.setApiClient(apiClient);
     }

--- a/src/main/java/org/gitlab4j/api/GitLabApi.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApi.java
@@ -9,6 +9,7 @@ import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.ws.rs.client.Client;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -639,6 +640,10 @@ public class GitLabApi implements AutoCloseable {
      */
     public void enableRequestResponseLogging(Logger logger, Level level, int maxEntitySize, List<String> maskedHeaderNames) {
         apiClient.enableRequestResponseLogging(logger, level, maxEntitySize, maskedHeaderNames);
+    }
+
+    public void setApiClient(Client apiClient) {
+        this.apiClient.setApiClient(apiClient);
     }
 
     /**

--- a/src/main/java/org/gitlab4j/api/GitLabApiClient.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApiClient.java
@@ -790,6 +790,10 @@ public class GitLabApiClient implements AutoCloseable {
         return (apiClient);
     }
 
+    public void setApiClient(Client apiClient) {
+        this.apiClient = apiClient;
+    }
+
     protected Invocation.Builder invocation(URL url, MultivaluedMap<String, String> queryParams, String accept) {
 
         if (apiClient == null) {

--- a/src/main/java/org/gitlab4j/api/Pager.java
+++ b/src/main/java/org/gitlab4j/api/Pager.java
@@ -6,9 +6,11 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
@@ -40,6 +42,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @param <T> the GitLab4J type contained in the List.
  */
 public class Pager<T> implements Iterator<List<T>>, Constants {
+    private final static Logger LOGGER = Logger.getLogger(Pager.class.getName());
 
     private int itemsPerPage;
     private int totalPages;
@@ -92,7 +95,7 @@ public class Pager<T> implements Iterator<List<T>>, Constants {
         Response response = api.get(Response.Status.OK, queryParams, pathArgs);
 
         try {
-            currentItems = mapper.readValue((InputStream) response.getEntity(), javaType);
+            currentItems = mapper.convertValue(response.readEntity(new GenericType<List<T>>() {}), javaType);
         } catch (Exception e) {
             throw new GitLabApiException(e);
         }


### PR DESCRIPTION
## Change description

The existing API client doesn't use OKHTTP...and doesn't support it either. 
This enables overriding the API client interface with whatever we want. 

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
