### PR TITLE
Moving custom Javax Client to Gitlab Repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.gitlab4j</groupId>
 	<artifactId>gitlab4j-api-cortex</artifactId>
 	<packaging>jar</packaging>
-	<version>4.20.3</version>
+	<version>4.20.4</version>
 	<name>GitLab4J-API - GitLab API Java Client</name>
 	<description>GitLab4J-API (gitlab4j-api) provides a full featured Java client library for working with GitLab repositories and servers via the GitLab REST API.</description>
 	<url>https://github.com/gitlab4j/gitlab4j-api</url>
@@ -461,6 +461,21 @@
 			<artifactId>junit-toolbox</artifactId>
 			<version>2.4</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.resteasy</groupId>
+			<artifactId>resteasy-client</artifactId>
+			<version>3.15.3.Final</version>
+		</dependency>
+		<dependency>
+			<groupId>net.ltgt.jaxrs</groupId>
+			<artifactId>resteasy-client-okhttp3</artifactId>
+			<version>1.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>4.9.3</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/gitlab4j/api/http/OkHttpResteasyClientFactory.java
+++ b/src/main/java/org/gitlab4j/api/http/OkHttpResteasyClientFactory.java
@@ -1,0 +1,30 @@
+package org.gitlab4j.api.http;
+
+import net.ltgt.resteasy.client.okhttp3.OkHttpClientEngine;
+import okhttp3.OkHttpClient;
+import org.gitlab4j.api.utils.JacksonJson;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.jackson.JacksonFeature;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+
+public class OkHttpResteasyClientFactory {
+    public static ResteasyClient getClient(OkHttpClient client) {
+        ResteasyProviderFactory instance = ResteasyProviderFactory.getInstance();
+        instance.registerProvider(JacksonJson.class);
+        RegisterBuiltin.register(instance);
+
+        ClientConfiguration clientConfig = new ClientConfiguration(instance);
+        clientConfig.property(ClientProperties.FEATURE_AUTO_DISCOVERY_DISABLE, true);
+        clientConfig.property(ClientProperties.METAINF_SERVICES_LOOKUP_DISABLE, true);
+
+        return new ResteasyClientBuilder().providerFactory(instance)
+            .register(JacksonFeature.class)
+            .httpEngine(new OkHttpClientEngine(client))
+            .withConfig(clientConfig)
+            .build();
+    }
+}

--- a/src/main/java/org/gitlab4j/api/http/OkHttpResteasyClientFactory.java
+++ b/src/main/java/org/gitlab4j/api/http/OkHttpResteasyClientFactory.java
@@ -5,6 +5,7 @@ import okhttp3.OkHttpClient;
 import org.gitlab4j.api.utils.JacksonJson;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.jackson.JacksonFeature;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
@@ -23,6 +24,7 @@ public class OkHttpResteasyClientFactory {
 
         return new ResteasyClientBuilder().providerFactory(instance)
             .register(JacksonFeature.class)
+            .register(MultiPartFeature.class)
             .httpEngine(new OkHttpClientEngine(client))
             .withConfig(clientConfig)
             .build();

--- a/src/main/java/org/gitlab4j/api/http/OkHttpResteasyClientFactory.java
+++ b/src/main/java/org/gitlab4j/api/http/OkHttpResteasyClientFactory.java
@@ -3,30 +3,22 @@ package org.gitlab4j.api.http;
 import net.ltgt.resteasy.client.okhttp3.OkHttpClientEngine;
 import okhttp3.OkHttpClient;
 import org.gitlab4j.api.utils.JacksonJson;
-import org.glassfish.jersey.client.ClientProperties;
-import org.glassfish.jersey.jackson.JacksonFeature;
-import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
-import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 
 public class OkHttpResteasyClientFactory {
     public static ResteasyClient getClient(OkHttpClient client) {
         ResteasyProviderFactory instance = ResteasyProviderFactory.getInstance();
-        instance.registerProvider(JacksonJson.class);
+        if (!instance.getClassContracts().containsKey(JacksonJson.class)) {
+            instance.registerProvider(JacksonJson.class);
+        }
+
         RegisterBuiltin.register(instance);
 
-        ClientConfiguration clientConfig = new ClientConfiguration(instance);
-        clientConfig.property(ClientProperties.FEATURE_AUTO_DISCOVERY_DISABLE, true);
-        clientConfig.property(ClientProperties.METAINF_SERVICES_LOOKUP_DISABLE, true);
-
         return new ResteasyClientBuilder().providerFactory(instance)
-            .register(JacksonFeature.class)
-            .register(MultiPartFeature.class)
             .httpEngine(new OkHttpClientEngine(client))
-            .withConfig(clientConfig)
             .build();
     }
 }


### PR DESCRIPTION
## Change description

Moving the custom RESTEasy client generation to this repo. 

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
