### PR TITLE
feat: CET-5075 add missing fields in ProjectApprovalsConfig

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.gitlab4j</groupId>
 	<artifactId>gitlab4j-api-cortex</artifactId>
 	<packaging>jar</packaging>
-	<version>6.0.2</version>
+	<version>6.0.3</version>
 	<name>GitLab4J-API - GitLab API Java Client</name>
 	<description>GitLab4J-API (gitlab4j-api) provides a full featured Java client library for working with GitLab repositories and servers via the GitLab REST API.</description>
 	<url>https://github.com/gitlab4j/gitlab4j-api</url>

--- a/src/main/java/org/gitlab4j/api/models/ProjectApprovalsConfig.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectApprovalsConfig.java
@@ -8,9 +8,11 @@ public class ProjectApprovalsConfig {
 
     private Integer approvalsBeforeMerge;
     private Boolean resetApprovalsOnPush;
+    private Boolean selectiveCodeOwnerRemovals;
     private Boolean disableOverridingApproversPerMergeRequest;
     private Boolean mergeRequestsAuthorApproval;
     private Boolean mergeRequestsDisableCommittersApproval;
+    private Boolean requirePasswordToApprove;
 
     public Integer getApprovalsBeforeMerge() {
         return approvalsBeforeMerge;
@@ -36,6 +38,19 @@ public class ProjectApprovalsConfig {
     public ProjectApprovalsConfig withResetApprovalsOnPush(Boolean resetApprovalsOnPush) {
         this.resetApprovalsOnPush = resetApprovalsOnPush;
         return (this);
+    }
+
+    public Boolean getSelectiveCodeOwnerRemovals() {
+        return selectiveCodeOwnerRemovals;
+    }
+
+    public void setSelectiveCodeOwnerRemovals(Boolean selectiveCodeOwnerRemovals) {
+        this.selectiveCodeOwnerRemovals = selectiveCodeOwnerRemovals;
+    }
+
+    public ProjectApprovalsConfig withSelectiveCodeOwnerRemovals(Boolean selectiveCodeOwnerRemovals) {
+        this.selectiveCodeOwnerRemovals = selectiveCodeOwnerRemovals;
+        return this;
     }
 
     public Boolean getDisableOverridingApproversPerMergeRequest() {
@@ -77,6 +92,19 @@ public class ProjectApprovalsConfig {
         return (this);
     }
 
+    public Boolean getRequirePasswordToApprove() {
+        return requirePasswordToApprove;
+    }
+
+    public void setRequirePasswordToApprove(Boolean requirePasswordToApprove) {
+        this.requirePasswordToApprove = requirePasswordToApprove;
+    }
+
+    public ProjectApprovalsConfig withRequirePasswordToApprove(Boolean requirePasswordToApprove) {
+        this.requirePasswordToApprove = requirePasswordToApprove;
+        return this;
+    }
+
     /**
      * Get the form params specified by this instance.
      *
@@ -84,11 +112,13 @@ public class ProjectApprovalsConfig {
      */
     @JsonIgnore
     public GitLabApiForm getForm() {
-	return new GitLabApiForm()
+        return new GitLabApiForm()
             .withParam("approvals_before_merge", approvalsBeforeMerge)
             .withParam("reset_approvals_on_push", resetApprovalsOnPush)
+            .withParam("selective_code_owner_removals", selectiveCodeOwnerRemovals)
             .withParam("disable_overriding_approvers_per_merge_request", disableOverridingApproversPerMergeRequest)
             .withParam("merge_requests_author_approval", mergeRequestsAuthorApproval)
-            .withParam("merge_requests_disable_committers_approval", mergeRequestsDisableCommittersApproval);
+            .withParam("merge_requests_disable_committers_approval", mergeRequestsDisableCommittersApproval)
+            .withParam("require_password_to_approve", requirePasswordToApprove);
     }
 }

--- a/src/test/resources/org/gitlab4j/api/project-approvals-config.json
+++ b/src/test/resources/org/gitlab4j/api/project-approvals-config.json
@@ -1,7 +1,9 @@
 {
   "approvals_before_merge": 2,
   "reset_approvals_on_push": true,
+  "selective_code_owner_removals": false,
   "disable_overriding_approvers_per_merge_request": false,
   "merge_requests_author_approval": false,
-  "merge_requests_disable_committers_approval": false
+  "merge_requests_disable_committers_approval": false,
+  "require_password_to_approve": false
 }


### PR DESCRIPTION
Jira ticket: https://cortex1.atlassian.net/browse/CET-5075

This PR adds two missing fields from ProjectApprovalsConfig and bumps version of the client to 6.0.3.

Missing fields where cherry-picked from upstream.

Link to PR that needs these changes: https://github.com/cortexapps/brain-backend/pull/4867