### PR TITLE
[feat]: add the ability to filter by group when fetching merge requests paginated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.gitlab4j</groupId>
 	<artifactId>gitlab4j-api-cortex</artifactId>
 	<packaging>jar</packaging>
-	<version>6.0.3</version>
+	<version>6.0.4</version>
 	<name>GitLab4J-API - GitLab API Java Client</name>
 	<description>GitLab4J-API (gitlab4j-api) provides a full featured Java client library for working with GitLab repositories and servers via the GitLab REST API.</description>
 	<url>https://github.com/gitlab4j/gitlab4j-api</url>

--- a/src/main/java/org/gitlab4j/api/MergeRequestApi.java
+++ b/src/main/java/org/gitlab4j/api/MergeRequestApi.java
@@ -71,6 +71,8 @@ public class MergeRequestApi extends AbstractApi {
             }
 
             response = get(Response.Status.OK, queryParams, "projects", filter.getProjectId(), "merge_requests");
+        } else if (filter != null && filter.getGroupId() != null && filter.getGroupId().intValue() > 0) {
+            response = get(Response.Status.OK, queryParams, "groups", filter.getGroupId(), "merge_requests");
         } else {
             response = get(Response.Status.OK, queryParams, "merge_requests");
         }


### PR DESCRIPTION
## Change description

We want the ability to add a group ID filter to the paginated merge request API that fetches merge requests using page number and page size.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
